### PR TITLE
fix for core config.php

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -132,7 +132,7 @@ class CI_Config {
 		{
 			foreach (array($file, ENVIRONMENT.DIRECTORY_SEPARATOR.$file) as $location)
 			{
-				$file_path = $path.'config/'.$location.'.php';
+				$file_path = realpath($path.'config/'.$location.'.php');
 				if (in_array($file_path, $this->is_loaded, TRUE))
 				{
 					return TRUE;


### PR DESCRIPTION
On WAMP we got "open_basedir restriction in effect. File(/) is not within the allowed path(s):" warning if use file_exist function with relative path. This fix it.